### PR TITLE
Initial commit / v 1.0.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+#
+# Exclude these files from release archives.
+# https://blog.madewithlove.be/post/gitattributes/
+#
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/.github export-ignore
+
+#
+# Auto detect text files and perform LF normalization
+# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
+#
+* text=auto

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,13 @@
+<!--
+This repository is only a convenience wrapper to easily install all PHPCompatibility PHPCS standards in one go.
+
+If your issue is related to the PHPCompatibility sniffs, please open an issue in the PHPCompatibility repository: https://github.com/PHPCompatibility/PHPCompatibility/issues
+
+If your issue is related to the PHPCompatibilityJoomla ruleset, please open an issue in the PHPCompatibilityJoomla repository: https://github.com/PHPCompatibility/PHPCompatibilityJoomla/issues
+
+If your issue is related to the PHPCompatibilityWP ruleset, please open an issue in the PHPCompatibilityWP repository: https://github.com/PHPCompatibility/PHPCompatibilityWP/issues
+
+Before opening a new issue, please search for duplicate issues to prevent opening a duplicate. If there is already an open issue, please leave a comment there.
+
+Thanks!
+-->

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor/
+composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+sudo: false
+
+dist: trusty
+
+language: php
+
+## Cache composer downloads.
+cache:
+  directories:
+    # Cache directory for older Composer versions.
+    - $HOME/.composer/cache/files
+    # Cache directory for more recent Composer versions.
+    - $HOME/.cache/composer/files
+
+php:
+  - 5.4
+  - 7.2
+
+matrix:
+  fast_finish: true
+
+before_install:
+  # Speed up build time by disabling Xdebug when its not needed.
+  - if [[ $COVERALLS_VERSION == "notset" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
+  - composer install
+
+script:
+  # Validate the composer.json file.
+  # @link https://getcomposer.org/doc/03-cli.md#validate
+  - composer validate --no-check-all --with-dependencies --strict

--- a/README.md
+++ b/README.md
@@ -1,1 +1,80 @@
+[![License](https://poser.pugx.org/PHPCompatibility/phpcompatibility-all/license.png)](https://github.com/PHPCompatibility/PHPCompatibilityAll/blob/master/LICENSE)
+[![Build Status](https://travis-ci.org/PHPCompatibility/PHPCompatibilityAll.png?branch=master)](https://travis-ci.org/PHPCompatibility/PHPCompatibilityAll)
+
 # PHPCompatibilityAll
+
+Convenience package to install all the external rulesets which the [PHPCompatibility organisation](https://github.com/PHPCompatibility) maintains, in one go using Composer.
+
+
+## What's included in this package ?
+
+### Base ruleset
+
+- [![PHPCompatibility Current Version](https://poser.pugx.org/phpcompatibility/php-compatibility/v/stable.png)](https://packagist.org/packages/phpcompatibility/php-compatibility) [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility) - External PHPCS standard to check your codebase for PHP cross-version compatibility.
+
+### Framework/CMS specific rulesets
+
+- [![PHPCompatibilityJoomla Current Version](https://poser.pugx.org/phpcompatibility/phpcompatibility-joomla/v/stable.png)](https://packagist.org/packages/PHPCompatibility/phpcompatibility-joomla) [PHPCompatibilityJoomla](https://github.com/PHPCompatibility/PHPCompatibilityJoomla) - PHPCompatibility ruleset specific for Joomla projects.
+- [![PHPCompatibilityWP Current Version](https://poser.pugx.org/phpcompatibility/phpcompatibility-wp/v/stable.png)](https://packagist.org/packages/PHPCompatibility/phpcompatibility-wp) [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) - PHPCompatibility ruleset specific for WordPress projects.
+
+
+## Requirements
+
+* PHP 5.3+ for use with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 2.3.0+.
+* PHP 5.4+ for use with [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer) 3.0.2+.
+* [Composer](https://getcomposer.org/)
+
+Use the latest stable release of PHP_CodeSniffer for the best results.
+
+
+## Installation instructions
+
+If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
+```bash
+composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.4.3 phpcompatibility/phpcompatibility-all:*
+composer install
+```
+
+If you already have a Composer PHPCS plugin installed, run:
+```bash
+composer require --dev phpcompatibility/phpcompatibility-all:*
+composer install
+```
+
+Next, run:
+```bash
+vendor/bin/phpcs -i
+```
+If all went well, you will now see that the PHPCompatibility, PHPCompatibilityJoomla and PHPCompatibilityWP standards are installed for PHP_CodeSniffer.
+
+
+## How to use
+
+Now you can use any of the following commands to inspect your code:
+```bash
+./vendor/bin/phpcs -p . --standard=PHPCompatibility
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityJoomla
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityWP
+```
+
+By default, you will only receive notifications about deprecated and/or removed PHP features.
+
+To get the most out of the PHPCompatibility standards, you should specify a `testVersion` to check against. That will enable the checks for both deprecated/removed PHP features as well as the detection of code using new PHP features.
+    - You can run the checks for just one specific PHP version by adding `--runtime-set testVersion 5.5` to your command line command.
+    - You can also specify a range of PHP versions that your code needs to support. In this situation, compatibility issues that affect any of the PHP versions in that range will be reported: `--runtime-set testVersion 5.3-5.5`.
+    - Since PHPCompatibility 7.1.3, you can omit one part of the range if you want to support everything above or below a particular version, i.e. use `--runtime-set testVersion 7.0-` to run all the checks for PHP 7.0 and above.
+
+For more detailed information, see the README of the main [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions) standard.
+
+
+## License
+
+All code within the PHPCompatibility organisation is released under the GNU Lesser General Public License (LGPL). For more information, visit https://www.gnu.org/copyleft/lesser.html
+
+
+## Changelog
+
+### 1.0.0 - 2018-07-17
+
+Initial release containing the PHPCompatibility, PHPCompatibilityJoomla and PHPCompatibilityWP rulesets.
+

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,30 @@
+{
+  "name" : "phpcompatibility/phpcompatibility-all",
+  "description" : "A set of external standards for PHP_CodeSniffer that check for PHP version compatibility and can modernize code.",
+  "type" : "phpcodesniffer-standard",
+  "keywords" : [ "compatibility", "phpcs", "standards", "joomla", "wordpress" ],
+  "homepage" : "http://phpcompatibility.com/",
+  "license" : "LGPL-3.0-or-later",
+  "authors" : [ {
+    "name" : "Wim Godden",
+    "role" : "lead"
+  },
+  {
+    "name" : "Juliette Reinders Folmer",
+    "role" : "lead"
+  } ],
+  "support" : {
+    "issues" : "https://github.com/PHPCompatibility/PHPCompatibilityAll/issues",
+    "source" : "https://github.com/PHPCompatibility/PHPCompatibilityAll"
+  },
+  "require" : {
+    "phpcompatibility/php-compatibility" : "*",
+    "phpcompatibility/phpcompatibility-wp" : "*",
+    "phpcompatibility/phpcompatibility-joomla" : "*"
+  },
+  "suggest" : {
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+    "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
+  },
+  "prefer-stable" : true
+}


### PR DESCRIPTION
This repository is intended as a convenience package to enable people to easily install all the PHPCS standards in the PHPCompatibility organisation in one go using Composer.

In other words: the only "functionality" which will be contained within this package will be the `composer.json` file.
In due time, more standards may be added to that file.

Notes:
- Adds `composer.json` file which requires all standards currently offered by the PHPCompatibility organisation.
- Adds a Travis config to validate the Composer configuration on each update.
- Adds README with basic installation and usage instructions.
- Adds LGPL v3 License.
- Adds `.gitignore` to ignore the `vendor` directory and the `composer.lock` file.
- Adds `.gitattributes` to keep release archives clean.
- Adds `.github/issue_template.md` to try and prevent issues related to the standards from being opened in this repository.


FYI: The build won't pass until PR https://github.com/PHPCompatibility/PHPCompatibility/pull/689, PR https://github.com/PHPCompatibility/PHPCompatibilityJoomla/pull/1 and PR https://github.com/PHPCompatibility/PHPCompatibilityWP/pull/1 have been merged, the PHPCompatibility package has been updated on Packagist and the Joomla and WP packages have been added to Packagist.