### PR TITLE
Travis: don't validate composer.json of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,4 +27,4 @@ before_install:
 script:
   # Validate the composer.json file.
   # @link https://getcomposer.org/doc/03-cli.md#validate
-  - composer validate --no-check-all --with-dependencies --strict
+  - composer validate --no-check-all --strict


### PR DESCRIPTION
That's their own responsibility (and would fail our build as PHPCompatibility needs to update the license).