### PR TITLE
Version 1.1.0 / Add new Polyfill rulesets

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,13 +1,18 @@
 <!--
-This repository is only a convenience wrapper to easily install all PHPCompatibility PHPCS standards in one go.
+This repository is only a convenience wrapper to easily install all PHPCompatibility PHP_CodeSniffer standards in one go.
 
 If your issue is related to the PHPCompatibility sniffs, please open an issue in the PHPCompatibility repository: https://github.com/PHPCompatibility/PHPCompatibility/issues
 
-If your issue is related to the PHPCompatibilityJoomla ruleset, please open an issue in the PHPCompatibilityJoomla repository: https://github.com/PHPCompatibility/PHPCompatibilityJoomla/issues
+If your issue is related to a framework specific ruleset, please open an issue in the relevant repository:
+* PHPCompatibilityJoomla: https://github.com/PHPCompatibility/PHPCompatibilityJoomla/issues
+* PHPCompatibilityWP: https://github.com/PHPCompatibility/PHPCompatibilityWP/issues
 
-If your issue is related to the PHPCompatibilityWP ruleset, please open an issue in the PHPCompatibilityWP repository: https://github.com/PHPCompatibility/PHPCompatibilityWP/issues
+If your issue is related to a polyfill specific ruleset, please open an issue in the relevant repository:
+* PHPCompatibilityParagonie: https://github.com/PHPCompatibility/PHPCompatibilityParagonie/issues
+* PHPCompatibilityPasswordCompat: https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat/issues
+* PHPCompatibilitySymfony: https://github.com/PHPCompatibility/PHPCompatibilitySymfony/issues
 
-Before opening a new issue, please search for duplicate issues to prevent opening a duplicate. If there is already an open issue, please leave a comment there.
+Before opening a new issue, please search for your issue to prevent opening a duplicate. If there is already an open issue, please leave a comment there.
 
 Thanks!
 -->

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ language: php
 ## Cache composer downloads.
 cache:
   directories:
-    # Cache directory for older Composer versions.
-    - $HOME/.composer/cache/files
-    # Cache directory for more recent Composer versions.
     - $HOME/.cache/composer/files
 
 php:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Convenience package to install all the external PHP_CodeSniffer rulesets which t
 - [![PHPCompatibilityJoomla Current Version](https://poser.pugx.org/phpcompatibility/phpcompatibility-joomla/v/stable.png)](https://packagist.org/packages/PHPCompatibility/phpcompatibility-joomla) [PHPCompatibilityJoomla](https://github.com/PHPCompatibility/PHPCompatibilityJoomla) - PHPCompatibility ruleset specific for Joomla projects.
 - [![PHPCompatibilityWP Current Version](https://poser.pugx.org/phpcompatibility/phpcompatibility-wp/v/stable.png)](https://packagist.org/packages/PHPCompatibility/phpcompatibility-wp) [PHPCompatibilityWP](https://github.com/PHPCompatibility/PHPCompatibilityWP) - PHPCompatibility ruleset specific for WordPress projects.
 
+### Polyfill provider specific rulesets
+- [![PHPCompatibilityPasswordCompat Current Version](https://poser.pugx.org/phpcompatibility/phpcompatibility-passwordcompat/v/stable.png)](https://packagist.org/packages/phpcompatibility/phpcompatibility-passwordcompat) [PHPCompatibilityPasswordCompat](https://github.com/PHPCompatibility/PHPCompatibilityPasswordCompat) - PHPCompatibility ruleset specific for projects which use @ircmaxell's [`password_compat`](https://github.com/ircmaxell/password_compat) polyfill library.
+- [![PHPCompatibilityParagonie Current Version](https://poser.pugx.org/PHPCompatibility/phpcompatibility-paragonie/v/stable.png)](https://packagist.org/packages/phpcompatibility/phpcompatibility-paragonie) [PHPCompatibilityParagonie](https://github.com/PHPCompatibility/PHPCompatibilityParagonie) - PHPCompatibility rulesets for projects using either the Paragonie [`random_compat`](https://github.com/paragonie/random_compat) or the Paragonie [`sodium_compat`](https://github.com/paragonie/sodium_compat) polyfill library, or both.
+- [![PHPCompatibilitySymfony Current Version](https://poser.pugx.org/PHPCompatibility/phpcompatibility-symfony/v/stable.png)](https://packagist.org/packages/phpcompatibility/phpcompatibility-symfony) [PHPCompatibilitySymfony](https://github.com/PHPCompatibility/PHPCompatibilitySymfony) - PHPCompatibility rulesets for projects using any of the [PHP polyfill libraries](https://github.com/symfony?utf8=?&q=polyfill) provided by the Symfony project.
+    For more details about the available rulesets, please check out the [README of the PHPCompatibilitySymfony](https://github.com/PHPCompatibility/PHPCompatibilitySymfony/blob/master/README.md) repository.
+
 
 ## Requirements
 
@@ -25,6 +31,7 @@ Convenience package to install all the external PHP_CodeSniffer rulesets which t
 * [Composer](https://getcomposer.org/)
 
 Use the latest stable release of PHP_CodeSniffer for the best results.
+The minimum _recommended_ version of PHP_CodeSniffer is version 2.6.0.
 
 
 ## Installation instructions
@@ -35,7 +42,7 @@ composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.4.3 php
 composer install
 ```
 
-If you already have a Composer PHPCS plugin installed, run:
+If you already have a Composer PHP_CodeSniffer plugin installed, run:
 ```bash
 composer require --dev phpcompatibility/phpcompatibility-all:*
 composer install
@@ -45,7 +52,7 @@ Next, run:
 ```bash
 vendor/bin/phpcs -i
 ```
-If all went well, you will now see that the `PHPCompatibility`, `PHPCompatibilityJoomla` and `PHPCompatibilityWP` standards are installed for PHP_CodeSniffer.
+If all went well, you will now see that the `PHPCompatibility`, `PHPCompatibilityJoomla`, `PHPCompatibilityWP` and a number of polyfill related standards are installed for PHP_CodeSniffer.
 
 
 ## How to use
@@ -55,6 +62,15 @@ Now you can use any of the following commands to inspect your code:
 ./vendor/bin/phpcs -p . --standard=PHPCompatibility
 ./vendor/bin/phpcs -p . --standard=PHPCompatibilityJoomla
 ./vendor/bin/phpcs -p . --standard=PHPCompatibilityWP
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityPasswordCompat
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityParagonieRandomCompat
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityParagonieSodiumCompat
+./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP54
+./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP73
+...etc...
+
+# You can also combine the standards if your project uses several:
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityPasswordCompat,PHPCompatibilitySymfonyPolyfillPHP70,PHPCompatibilityWP
 ```
 
 By default, you will only receive notifications about deprecated and/or removed PHP features.
@@ -65,8 +81,24 @@ To get the most out of the PHPCompatibility standards, you should specify a `tes
 * You can also specify a range of PHP versions that your code needs to support. In this situation, compatibility issues that affect any of the PHP versions in that range will be reported: `--runtime-set testVersion 5.3-5.5`.
 * Since PHPCompatibility 7.1.3, you can omit one part of the range if you want to support everything above or below a particular version, i.e. use `--runtime-set testVersion 7.0-` to run all the checks for PHP 7.0 and above.
 
+For example:
+```bash
+# For a Joomla project which should be compatible with PHP 5.3 up to and including PHP 7.0:
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityJoomla --runtime-set testVersion 5.3-7.0
+
+# For a project using both the Paragonie Sodium Compat polyfill as well as the Symfony PHP 7.1 polyfill and which should be compatible with PHP 5.4 and higher:
+./vendor/bin/phpcs -p . --standard=PHPCompatibilityParagonieSodiumCompat,PHPCompatibilitySymfonyPolyfillPHP71 --runtime-set testVersion 5.4-
+```
+
 For more detailed information, see the README of the main [PHPCompatibility](https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions) standard.
 
+
+### Testing PHP files only
+
+By default PHP_CodeSniffer will analyse PHP, JavaScript and CSS files. As the PHPCompatibility sniffs only target PHP code, you can make the run slightly faster by telling PHP_CodeSniffer to only check PHP files, like so:
+```bash
+./vendor/bin/phpcs -p . --standard=PHPCompatibilitySymfonyPolyfillPHP56 --extensions=php --runtime-set testVersion 5.3-
+```
 
 ## License
 
@@ -75,6 +107,10 @@ For more information, visit https://www.gnu.org/copyleft/lesser.html
 
 
 ## Changelog
+
+### 1.1.0 - 2018-10-07
+
+- Added the new PHPCompatibilityPasswordCompat, PHPCompatibilityParagonie, PHPCompatibilitySymfony rulesets.
 
 ### 1.0.0 - 2018-07-17
 

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,8 @@
 {
   "name" : "phpcompatibility/phpcompatibility-all",
-  "description" : "A set of external standards for PHP_CodeSniffer that check for PHP version compatibility and can modernize code.",
+  "description" : "A set of rulesets for PHP_CodeSniffer to check for PHP cross-version compatibility issues and opportunities to modernize code in PHP projects.",
   "type" : "phpcodesniffer-standard",
-  "keywords" : [ "compatibility", "phpcs", "standards", "joomla", "wordpress" ],
+  "keywords" : [ "compatibility", "phpcs", "standards", "joomla", "wordpress", "polyfills", "paragonie", "password_compat", "symfony" ],
   "homepage" : "http://phpcompatibility.com/",
   "license" : "LGPL-3.0-or-later",
   "authors" : [ {
@@ -20,10 +20,13 @@
   "require" : {
     "phpcompatibility/php-compatibility" : "*",
     "phpcompatibility/phpcompatibility-wp" : "*",
-    "phpcompatibility/phpcompatibility-joomla" : "*"
+    "phpcompatibility/phpcompatibility-joomla" : "*",
+    "phpcompatibility/phpcompatibility-paragonie" : "*",
+    "phpcompatibility/phpcompatibility-passwordcompat" : "*",
+    "phpcompatibility/phpcompatibility-symfony" : "*"
   },
   "suggest" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHPCS 'installed_paths' automatically.",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.4.3 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
     "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
   },
   "prefer-stable" : true


### PR DESCRIPTION
:warning: **IMPORTANT** :warning:
The build for this PR will not pass until PHPCompatibility 9.0.0 and the polyfill and CMS rulesets have been released.  This PR should not be merged until then. 

---

This update accounts for the following changes:
* Composer:
    - Require the polyfill repos.
    - Improved the project description and added to the keywords.
* Travis: remove old caching reference. The travis images now do a `composer self-update` by default.
* Issue template: updated to point to the additional repos.
* Readme:
    - Added information about the polyfill rulesets.
    - Added section about only testing PHP files.
    - Added changelog for version 1.1.0.