### PR TITLE
Build/Travis: test builds against PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,14 @@ cache:
 
 php:
   - 5.4
-  - 7.2
+  - 7.3
 
 matrix:
   fast_finish: true
 
 before_install:
   # Speed up build time by disabling Xdebug when its not needed.
-  - if [[ $COVERALLS_VERSION == "notset" ]]; then phpenv config-rm xdebug.ini || echo 'No xdebug config.'; fi
+  - phpenv config-rm xdebug.ini || echo 'No xdebug config.'
   - composer install
 
 script:


### PR DESCRIPTION
PHP 7.3 is now available on Travis, so testing against the highest supported PHP version should use PHP 7.3.

Also: as this repo does not use coveralls, the condition for disabling Xdebug made no sense, so removing it.