### PR TITLE
Update reference to the DealerDirect plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The minimum _recommended_ version of PHP_CodeSniffer is version 2.6.0.
 
 If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
 ```bash
-composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.4.3 phpcompatibility/phpcompatibility-all:*
+composer require --dev dealerdirect/phpcodesniffer-composer-installer:^0.5.0 phpcompatibility/phpcompatibility-all:*
 composer install
 ```
 


### PR DESCRIPTION
PR #8 updated the `composer.json` file to recommend version `^0.5.0` of the DealerDirect plugin, but the installation instructions in the readme hadn't been updated yet to reflect this.