### PR TITLE
Travis: minor tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-sudo: false
-
 dist: trusty
 
 language: php
@@ -11,7 +9,7 @@ cache:
 
 php:
   - 5.4
-  - 7.3
+  - 7.4
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
* Support for `sudo` has been removed for quite a while now.
* Let's use PHP 7.4 as the "high" PHP version.