### PR TITLE
README: update for Composer 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,14 +38,13 @@ The minimum _recommended_ version of PHP_CodeSniffer is version 2.6.0.
 
 If you don't have a Composer plugin installed to manage the `installed_paths` setting for PHP_CodeSniffer, run the following from the command-line:
 ```bash
+composer config allow-plugins.dealerdirect/phpcodesniffer-composer-installer true
 composer require --dev dealerdirect/phpcodesniffer-composer-installer:"^0.7" phpcompatibility/phpcompatibility-all:"*"
-composer install
 ```
 
 If you already have a Composer PHP_CodeSniffer plugin installed, run:
 ```bash
 composer require --dev phpcompatibility/phpcompatibility-all:"*"
-composer install
 ```
 
 Next, run:


### PR DESCRIPTION
Using the `dealerdirect/phpcodesniffer-composer-installer` Composer plugin is recommended to register external PHPCS standards with PHPCS.

As of Composer 2.2.0, Composer plugins need to be explicitly allowed to run.

This commit adds the CLI command to set those permissions to the installation instructions.

Includes removing a few redundant `composer install`s.

Refs:
* https://blog.packagist.com/composer-2-2/#more-secure-plugin-execution