### PR TITLE
Composer: update the suggestion version of the Composer PHPCS plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "phpcompatibility/phpcompatibility-symfony" : "*"
   },
   "suggest" : {
-    "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
+    "dealerdirect/phpcodesniffer-composer-installer": "^1.0 || This Composer plugin will sort out the PHP_CodeSniffer 'installed_paths' automatically.",
     "roave/security-advisories": "dev-master || Helps prevent installing dependencies with known security issues."
   },
   "prefer-stable" : true


### PR DESCRIPTION
The Composer PHPCS plugin has released its 1.0.0 version. :tada:

Ref: https://github.com/PHPCSStandards/composer-installer/releases/tag/v1.0.0